### PR TITLE
Added skid caching/reapply feature

### DIFF
--- a/src/Constants.as
+++ b/src/Constants.as
@@ -1,4 +1,5 @@
 string SKIDS_GITHUB_REPO = "snixtho/tm2020-skids";
 string SKIDS_GITHUB_LIST_PATH = "Skids";
 string SKIDS_MASTER_BRANCH_NAME = "master";
+string SKIDS_CONFIG = "skidConfig.json";
 bool IS_DEV_MODE = Meta::ExecutingPlugin().get_Type() == Meta::PluginType::Folder;

--- a/src/Interface/Tabs/Advanced.as
+++ b/src/Interface/Tabs/Advanced.as
@@ -1,10 +1,25 @@
 class AdvancedTab : Tab {
+
+
     string GetLabel() override { return Icons::Cog + " Advanced"; }
 
     void Render() override
     {
-        UI::Text("Delete all custom skid marks and other customizations.");
-        UI::Text("Don't forget to restart the game after deleting to apply the changes.");
+        UI::Text("Apply or delete all custom skid marks and other customizations.");
+        UI::Text("Don't forget to rejoin the map after to apply the changes.");
+        if (UI::GreenButton(Icons::Check + " Apply all customizations"))
+        {
+            array<SkidTypeTab@> tabs = g_window.skidTabs;
+            for(uint i = 0; i < tabs.Length; i++)
+            {
+                SkidTypeTab@ tab = tabs[i];
+                if(tab.skidType !is null && tab.defaultSkid !is null)
+                {
+                    Skids::ApplyToGame(tab.skidType, tab.defaultSkid, tab);
+                }
+            }
+            UI::ShowNotification(Icons::Check + " " + Meta::ExecutingPlugin().Name, "All customizations have been applied.\nPlease rejoin the map to apply changes.");
+        }
         if (UI::RedButton(Icons::Trash + " Delete all customizations"))
         {
             Skids::DeleteAll();

--- a/src/Interface/Tabs/SkidTypeTab.as
+++ b/src/Interface/Tabs/SkidTypeTab.as
@@ -4,6 +4,7 @@ class SkidTypeTab : Tab {
 
     string selectedSkidName;
     Skid@ selectedSkid;
+    Skid@ defaultSkid;
 
     bool isSkidApplied = false;
     bool isSkidDeleted = false;
@@ -17,6 +18,18 @@ class SkidTypeTab : Tab {
         @skidType = type;
     }
 
+    void SetDefaultSkid(Skid@ skid, bool select = true)
+    {
+        @defaultSkid = @skid;
+        g_config.data[skidType.name] = skid.name;
+        g_config.Save();
+        if(select)
+        {
+            @selectedSkid = @skid;
+            selectedSkidName = selectedSkid.name;
+        }
+    }
+
     string GetLabel() override { return skidType.name; }
 
     vec4 GetColor() override {
@@ -25,6 +38,14 @@ class SkidTypeTab : Tab {
         else if (skidType.name == "Grass") return vec4(0.0, 0.5, 0.0, 1.0);
 
         else return vec4(0.2f, 0.4f, 0.8f, 1);
+    }
+
+    void Apply()
+    {
+        g_config.data["dirtDisableSmoke"] = dirtSkidDisableSmoke;
+        g_config.Save();
+        SetDefaultSkid(selectedSkid, false);
+        Skids::ApplyToGame(skidType, selectedSkid, this);
     }
 
     void Render() override
@@ -52,11 +73,11 @@ class SkidTypeTab : Tab {
         }
         if (!isSkidInProgress) {
             if (skidType.name == "Dirt") {
-                dirtSkidDisableSmoke = UI::Checkbox("Disable Dirt Smoke", dirtSkidDisableSmoke);
+                dirtSkidDisableSmoke = UI::Checkbox("Disable Dirt Smoke (May require game restart)", dirtSkidDisableSmoke);
             }
             if (selectedSkidName.Length > 0) {
                 if (UI::GreenButton(Icons::Check + " Apply")) {
-                    Skids::ApplyToGame(skidType, selectedSkid, this);
+                    Apply();
                 }
                 UI::SameLine();
             }
@@ -78,7 +99,7 @@ class SkidTypeTab : Tab {
             UI::Text("\\$0f0"+Icons::Check+" \\$zYour Skid is Deleted!");
         }
         if (needGameRestart) {
-            UI::Text(Icons::ExclamationTriangle + " Don't forget to restart the game to apply the changes.");
+            UI::Text(Icons::ExclamationTriangle + " Don't forget to rejoin the map to apply the changes.");
         }
         UI::EndChild();
 

--- a/src/Interface/Window.as
+++ b/src/Interface/Window.as
@@ -3,8 +3,10 @@ class Window
     bool isOpened = false;
 
     array<Tab@> tabs;
+    array<SkidTypeTab@> skidTabs;
     Tab@ activeTab;
     Tab@ c_lastActiveTab;
+
 
     Window()
     {
@@ -12,10 +14,13 @@ class Window
         AddTab(AdvancedTab());
     }
 
-    void AddTab(Tab@ tab, bool select = false){
+    void AddTab(Tab@ tab, bool select = false, bool isSkidTab = false){
         tabs.InsertLast(tab);
         if (select) {
             @activeTab = tab;
+        }
+        if (isSkidTab){
+            skidTabs.InsertLast(cast<SkidTypeTab@>(tab));
         }
     }
 

--- a/src/Main.as
+++ b/src/Main.as
@@ -1,8 +1,10 @@
 Window@ g_window;
 Repo@ g_repo;
+Config@ g_config;
 
 void Main()
 {
+    @g_config = Config();
     @g_window = Window();
     @g_repo = Repo();
 }

--- a/src/Utils/ApplySkidToGame.as
+++ b/src/Utils/ApplySkidToGame.as
@@ -89,9 +89,18 @@ namespace Skids
     }
 
     void DeleteAll()
-    {
+    {   
+        array<SkidTypeTab@> tabs = g_window.skidTabs;
+        for(uint i = 0; i < tabs.Length; i++)
+        {
+            SkidTypeTab@ tab = tabs[i];
+            tab.isSkidApplied = false;
+            tab.isSkidDeleted = true;
+            tab.isSkidInProgress = false;
+            tab.needGameRestart = true;
+        }
         string modWorkDir = IO::FromUserGameFolder("Skins/Stadium/ModWork");
         IO::DeleteFolder(modWorkDir, true);
-        UI::ShowNotification(Icons::Check + " " + Meta::ExecutingPlugin().Name, "All customizations have been deleted.\nPlease restart your game to apply changes.");
+        UI::ShowNotification(Icons::Check + " " + Meta::ExecutingPlugin().Name, "All customizations have been deleted.\nPlease rejoin the map to apply changes.");
     }
 }

--- a/src/Utils/Config.as
+++ b/src/Utils/Config.as
@@ -1,0 +1,28 @@
+class Config
+{
+    Json::Value data = Json::Object();
+
+    Config()
+    {
+        Load();
+    }
+
+    void Load()
+    {
+        if(IO::FileExists(SKIDS_CONFIG))
+        {  
+            data = Json::FromFile(SKIDS_CONFIG);
+            trace("Loaded skid config.");
+        }
+        else
+        {
+            trace("Could not locate a skid config.");
+        }
+    }
+
+    void Save(){
+        Json::ToFile(SKIDS_CONFIG, data);
+        trace("Saved skid config.");
+    }
+
+}

--- a/src/Utils/SkidType.as
+++ b/src/Utils/SkidType.as
@@ -101,6 +101,27 @@ class SkidType
             skids.InsertLast(skid);
         }
         print("Loaded " + skids.Length + " skids for " + name + " type");
-        g_window.AddTab(SkidTypeTab(this));
+        SkidTypeTab@ tab = SkidTypeTab(this);
+        if(skids.Length > 0)
+        {
+            Skid@ defaultSkid = skids[0];
+            if(g_config.data.HasKey(name))
+            {
+                string skidName = g_config.data[name];
+                for(uint i = 0; i < skids.Length; i++)
+                {
+                    if(skidName == skids[i].name){
+                        trace("Found default: " + skidName);
+                        Skid@ defaultSkid = skids[i];
+                        tab.SetDefaultSkid(defaultSkid);
+                    }
+                }
+            }
+            else tab.SetDefaultSkid(defaultSkid);
+        }
+        if(g_config.data.HasKey("dirtDisableSmoke"))
+            tab.dirtSkidDisableSmoke = g_config.data["dirtDisableSmoke"];
+        
+        g_window.AddTab(tab, false, true);
     }
 }


### PR DESCRIPTION
I added some caching of the last applied skids, that way it will automatically opens to your last used skid on each surface. Then I added a button to reapply all your skids in one click. This means you can now remove/apply all your preferred skids much faster, rather than needing to search for your skid and reapply it for every surface.

I also reworded some text to tell you to rejoin the map, rather than restart the game. As far as I can tell a restart is only necessary when changing dirt smoke. This led to a lot of people thinking they had to fully restart their game every time they disabled/enabled skids. However if there are other reasons to restart the game that I'm not aware of then I'm happy to change the wording back. 

Lastly I made a small change so that it would correctly remove the "skid is applied" text when clicking the delete all button. 
